### PR TITLE
Allow unwrap custom active_job.queue_adapter

### DIFF
--- a/lib/sidekiq/throttled.rb
+++ b/lib/sidekiq/throttled.rb
@@ -75,10 +75,10 @@ module Sidekiq
       #
       # @param [String] message Job's JSON payload
       # @return [Boolean]
-      def throttled?(message) # rubocop:disable Metrics/MethodLength
+      def throttled?(message)
         message = JSON.parse message
-        job = message.fetch("wrapped", message.fetch("class", false))
-        jid = message.fetch("jid", false)
+        job = message.fetch("wrapped") { message.fetch("class") { return false } }
+        jid = message.fetch("jid") { return false }
 
         preload_constant! job
 

--- a/lib/sidekiq/throttled.rb
+++ b/lib/sidekiq/throttled.rb
@@ -77,9 +77,8 @@ module Sidekiq
       # @return [Boolean]
       def throttled?(message) # rubocop:disable Metrics/MethodLength
         message = JSON.parse message
-        job = message.fetch("class")   { return false }
-        job = message.fetch("wrapped") { return false } if job == "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper"
-        jid = message.fetch("jid")     { return false }
+        job = message.fetch("wrapped", message.fetch("class", false))
+        jid = message.fetch("jid", false)
 
         preload_constant! job
 

--- a/spec/sidekiq/throttled_spec.rb
+++ b/spec/sidekiq/throttled_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Sidekiq::Throttled, :sidekiq => :disabled do
       described_class.throttled? message
     end
 
-    it "unwraps ActiveJob-jobs" do
+    it "unwraps ActiveJob-jobs default sidekiq adapter" do
       strategy = Sidekiq::Throttled::Registry.add("wrapped-foo",
         :threshold   => { :limit => 1, :period => 1 },
         :concurrency => { :limit => 1 })
@@ -64,6 +64,23 @@ RSpec.describe Sidekiq::Throttled, :sidekiq => :disabled do
       message     = JSON.dump({
         "class"   => "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper",
         "wrapped" => "wrapped-foo",
+        "jid"     => payload_jid
+      })
+
+      expect(strategy).to receive(:throttled?).with payload_jid
+
+      described_class.throttled? message
+    end
+
+    it "unwraps ActiveJob-jobs custom sidekiq adapter" do
+      strategy = Sidekiq::Throttled::Registry.add("JobClassName",
+        :threshold   => { :limit => 1, :period => 1 },
+        :concurrency => { :limit => 1 })
+
+      payload_jid = jid
+      message     = JSON.dump({
+        "class"   => "ActiveJob::QueueAdapters::SidekiqCustomAdapter::JobWrapper",
+        "wrapped" => "JobClassName",
         "jid"     => payload_jid
       })
 


### PR DESCRIPTION
Small improvement from https://github.com/sensortower/sidekiq-throttled/pull/116 to allow unwrap of custom job adapters