### PR TITLE
fix timeout deprecation warning for redis 4.8.0

### DIFF
--- a/lib/sidekiq/throttled/fetch.rb
+++ b/lib/sidekiq/throttled/fetch.rb
@@ -77,7 +77,7 @@ module Sidekiq
           return
         end
 
-        Sidekiq.redis { |conn| conn.brpop(*queues, TIMEOUT) }
+        Sidekiq.redis { |conn| conn.brpop(*queues, timeout: TIMEOUT) }
       end
 
       # Returns list of queues to try to fetch jobs from.

--- a/lib/sidekiq/throttled/fetch.rb
+++ b/lib/sidekiq/throttled/fetch.rb
@@ -77,7 +77,7 @@ module Sidekiq
           return
         end
 
-        Sidekiq.redis { |conn| conn.brpop(*queues, timeout: TIMEOUT) }
+        Sidekiq.redis { |conn| conn.brpop(*queues, :timeout => TIMEOUT) }
       end
 
       # Returns list of queues to try to fetch jobs from.

--- a/spec/sidekiq/throttled/fetch_spec.rb
+++ b/spec/sidekiq/throttled/fetch_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Sidekiq::Throttled::Fetch, :sidekiq => :disabled do
           expect(fetcher.retrieve_work).to be_nil
 
           expect(redis).to receive(:brpop)
-            .with("queue:dreamers", 2)
+            .with("queue:dreamers", { :timeout => 2 })
 
           expect(fetcher.retrieve_work).to be_nil
         end
@@ -114,7 +114,7 @@ RSpec.describe Sidekiq::Throttled::Fetch, :sidekiq => :disabled do
         it "builds correct redis brpop command" do
           Sidekiq.redis do |conn|
             expect(conn).to receive(:brpop)
-              .with("queue:heroes", "queue:dreamers", {:timeout => 2})
+              .with("queue:heroes", "queue:dreamers", { :timeout => 2 })
             fetcher.retrieve_work
           end
         end
@@ -126,7 +126,7 @@ RSpec.describe Sidekiq::Throttled::Fetch, :sidekiq => :disabled do
         it "builds correct redis brpop command" do
           Sidekiq.redis do |conn|
             queue_regexp = %r{^queue:(heroes|dreamers)$}
-            expect(conn).to receive(:brpop).with(queue_regexp, queue_regexp, {:timeout => 2})
+            expect(conn).to receive(:brpop).with(queue_regexp, queue_regexp, { :timeout => 2 })
             fetcher.retrieve_work
           end
         end

--- a/spec/sidekiq/throttled/fetch_spec.rb
+++ b/spec/sidekiq/throttled/fetch_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Sidekiq::Throttled::Fetch, :sidekiq => :disabled do
         it "builds correct redis brpop command" do
           Sidekiq.redis do |conn|
             expect(conn).to receive(:brpop)
-              .with("queue:heroes", "queue:dreamers", 2)
+              .with("queue:heroes", "queue:dreamers", {:timeout => 2})
             fetcher.retrieve_work
           end
         end
@@ -126,7 +126,7 @@ RSpec.describe Sidekiq::Throttled::Fetch, :sidekiq => :disabled do
         it "builds correct redis brpop command" do
           Sidekiq.redis do |conn|
             queue_regexp = %r{^queue:(heroes|dreamers)$}
-            expect(conn).to receive(:brpop).with(queue_regexp, queue_regexp, 2)
+            expect(conn).to receive(:brpop).with(queue_regexp, queue_regexp, {:timeout => 2})
             fetcher.retrieve_work
           end
         end


### PR DESCRIPTION
fixes deprecation notice: Passing the timeout as a positional argument is deprecated, it should now be passed as a keyword argument.

this change was introduced in redis 4.8.0 https://github.com/redis/redis-rb/blob/master/CHANGELOG.md#480

```
Passing the timeout as a positional argument is deprecated, it should be passed as a keyword argument:
  redis.brpop("queue:mailers", "queue:api_call", "queue:scheduled", "queue:searchkick", "queue:active_storage_analysis", "queue:active_storage_purge", "queue:default", timeout: 2)(called from: /home/xxx/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/sidekiq-throttled-0.16.2/lib/sidekiq/throttled/fetch.rb:94:in `block in brpop')
```

this should fix https://github.com/sensortower/sidekiq-throttled/issues/124